### PR TITLE
Add cross-subject headline rulebook preview

### DIFF
--- a/cross_subject_headline_rulebook_preview.md
+++ b/cross_subject_headline_rulebook_preview.md
@@ -1,0 +1,185 @@
+# CROSS-SUBJECT HEADLINE RULEBOOK PREVIEW
+
+*20–25 word blackletter headlines spanning core MBE topics. Mirrors full rulebook navigation for quick pre-exam review.*
+
+---
+
+## 1. CIVIL PROCEDURE – SUBJECT-MATTER JURISDICTION
+
+**Rule (22 words):** Federal courts need subject-matter jurisdiction via federal question, diversity exceeding $75,000 with complete diversity, or supplemental claims sharing common nucleus with anchor.
+
+**Major Subtopics:**
+- **Federal Question:** Well-pleaded complaint rule; embedded federal issues.
+- **Diversity:** Complete diversity, citizenship tests, amount-in-controversy.
+- **Supplemental Jurisdiction:** Same case or controversy, Gibbs discretion factors.
+- **Removal/Remand:** Defendant timing, forum defendant rule, procedural defects.
+
+## 2. CIVIL PROCEDURE – PERSONAL JURISDICTION
+
+**Rule (22 words):** State court exercises personal jurisdiction where statute authorizes and Due Process satisfied through minimum contacts, purposeful availment, foreseeability, and fairness plus notice.
+
+**Major Subtopics:**
+- **Long-Arm Statutes:** Enumerated acts vs. full constitutional reach.
+- **Traditional Bases:** Domicile, service in forum, consent/waiver.
+- **Specific Jurisdiction:** Relatedness of claim, purposeful availment, foreseeability.
+- **Fair Play Factors:** Burden, forum interest, efficiency, shared policies.
+
+## 3. CONSTITUTIONAL LAW – FEDERAL POWERS & SUPREMACY
+
+**Rule (24 words):** Congress legislates through enumerated powers, Necessary and Proper Clause, Commerce channels or substantial effects, while Supremacy Clause preempts conflicting state actions within enumerated sphere.
+
+**Major Subtopics:**
+- **Enumerated Powers:** Tax/Spend, War, Citizenship, Section Five enforcement.
+- **Commerce Authority:** Channels, instrumentalities, substantial effects tests.
+- **Preemption:** Express, field, conflict, obstacle analyses.
+- **Tenth Amendment Limits:** Anti-commandeering, state sovereignty protections.
+
+## 4. CONSTITUTIONAL LAW – INDIVIDUAL RIGHTS & SCRUTINY
+
+**Rule (24 words):** Government action triggering individual rights receives strict, intermediate, or rational basis scrutiny depending on classification or burden, requiring tailored means and adequate governmental objectives.
+
+**Major Subtopics:**
+- **State Action:** Public function, entanglement, government involvement tests.
+- **Fundamental Rights:** Travel, vote, privacy, marriage, parental rights.
+- **Equal Protection:** Suspect and quasi-suspect classifications, animus review.
+- **Speech Regulation:** Content-based strict scrutiny vs. content-neutral tests.
+
+## 5. CONTRACTS – OFFER, ACCEPTANCE, CONSIDERATION
+
+**Rule (23 words):** Valid contract needs offer showing commitment, acceptance mirroring material terms, and consideration or substitute reliance creating bargained-for exchange with mutual assent and capacity.
+
+**Major Subtopics:**
+- **Offer Dynamics:** Advertisements, revocation, option and firm offers.
+- **Acceptance Mechanics:** Mirror image, UCC 2-207, mailbox rule.
+- **Consideration:** Bargained-for exchange, past consideration, promissory estoppel.
+- **Formation Defenses:** Incapacity, illegality, mistake, misrepresentation.
+
+## 6. CONTRACTS – PERFORMANCE, BREACH, REMEDIES
+
+**Rule (23 words):** Performance judged by strict compliance for non-UCC or perfect tender under Article 2; material breach excuses; remedies include expectation, reliance, restitution, specific performance.
+
+**Major Subtopics:**
+- **Conditions:** Express, implied, constructive; waiver and prevention.
+- **Material Breach:** Substantial performance, divisibility, anticipatory repudiation.
+- **UCC Obligations:** Perfect tender, cure, installment contracts.
+- **Remedies:** Expectation, consequential limits, mitigation, equitable relief.
+
+## 7. TORTS – NEGLIGENCE ELEMENTS
+
+**Rule (22 words):** Negligence requires duty owed, breach by unreasonable conduct, actual and proximate causation, and damages; defenses include comparative fault, assumption of risk, statutes.
+
+**Major Subtopics:**
+- **Duty:** Reasonable person, special standards, affirmative duties.
+- **Breach:** Custom, negligence per se, res ipsa loquitur.
+- **Causation:** But-for, substantial factor, proximate foreseeability.
+- **Defenses:** Comparative fault, assumption of risk, immunities.
+
+## 8. TORTS – STRICT LIABILITY & PRODUCTS LIABILITY
+
+**Rule (23 words):** Strict liability covers abnormally dangerous activities, wild animals, and product defects proven through manufacturing, design, or warning failure where foreseeable plaintiffs suffer harm.
+
+**Major Subtopics:**
+- **Abnormally Dangerous:** High risk, cannot eliminate, uncommon in community.
+- **Products Liability:** Manufacturing, design, warning theories, risk-utility.
+- **Defenses:** Assumption of risk, comparative fault, statutes of repose.
+- **Warranties:** Express, implied merchantability, fitness, disclaimers.
+
+## 9. EVIDENCE – RELEVANCE & CHARACTER
+
+**Rule (24 words):** Evidence must be relevant, probative value not outweighed by unfair prejudice; character evidence limited except for habit, impeachment, or cases placing character at issue.
+
+**Major Subtopics:**
+- **Rule 403:** Probative value vs. prejudice balancing, limiting instructions.
+- **Character Evidence:** Civil propensity bar, criminal defendant’s opening door.
+- **Other Acts:** Rule 404(b) non-propensity purposes, notice requirements.
+- **Impeachment:** Character for truthfulness, prior convictions, contradiction.
+
+## 10. EVIDENCE – HEARSAY & EXCEPTIONS
+
+**Rule (24 words):** Hearsay is out-of-court statement offered for truth, inadmissible absent exemption or exception such as opposing party statements, present sense impression, excited utterance, business records.
+
+**Major Subtopics:**
+- **Non-Hearsay Uses:** Effect on listener, verbal acts, impeachment.
+- **Exemptions:** Prior statements, opposing party admissions, adoptive silence.
+- **Unavailable Declarant:** Former testimony, dying declarations, statements against interest.
+- **Reliability Exceptions:** Present sense impression, excited utterance, medical, business records.
+
+## 11. CRIMINAL LAW – MENS REA & HOMICIDE
+
+**Rule (25 words):** Criminal liability requires actus reus with mens rea of purpose, knowledge, recklessness, or negligence; homicide classifications depend on malice aforethought, intent, depraved heart, felony murder.
+
+**Major Subtopics:**
+- **Mens Rea Levels:** Purpose, knowledge, recklessness, negligence, strict liability.
+- **Murder:** Intentional, depraved heart, felony murder limits.
+- **Manslaughter:** Voluntary provocation, involuntary criminal negligence.
+- **Defenses:** Self-defense, insanity tests, intoxication doctrines.
+
+## 12. CRIMINAL PROCEDURE – SEARCH, SEIZURE, STATEMENTS
+
+**Rule (24 words):** Fourth Amendment protects reasonable expectations of privacy; warrants need probable cause and particularity; exclusionary rule suppressed violations; Fifth and Sixth regulate interrogation, counsel, identifications.
+
+**Major Subtopics:**
+- **Standing:** Reasonable expectation, overnight guests, car passengers.
+- **Warrant Exceptions:** Search incident, automobile, consent, plain view.
+- **Exclusionary Limits:** Good faith, attenuation, inevitable discovery.
+- **Interrogations:** Miranda custody, invocation, Sixth Amendment attachment.
+
+## 13. REAL PROPERTY – ESTATES & FUTURE INTERESTS
+
+**Rule (24 words):** Present estates include fee simple, life estates, and leaseholds; future interests vest in grantor or third parties subject to RAP, waste, and defeasibility doctrines.
+
+**Major Subtopics:**
+- **Fee Estates:** Fee simple absolute, defeasible fees distinctions.
+- **Life Estates:** Waste doctrine, ameliorative changes, duties.
+- **Future Interests:** Remainders vs. executory interests, vested classifications.
+- **RAP Analysis:** Validating life, class closing, savings clauses.
+
+## 14. REAL PROPERTY – CONVEYANCING & RECORDING
+
+**Rule (25 words):** Valid conveyance needs competent grantor, executed deed, delivery, and acceptance; recording acts protect bona fide purchasers without notice who record first depending on statute type.
+
+**Major Subtopics:**
+- **Deed Formalities:** Writing, signatures, descriptions, delivery intent.
+- **Notice Types:** Actual, record, inquiry; shelter rule.
+- **Recording Acts:** Race, notice, race-notice frameworks.
+- **Chain Issues:** Wild deeds, late recording, estoppel by deed.
+
+## 15. BUSINESS ASSOCIATIONS – AGENCY & PARTNERSHIPS
+
+**Rule (24 words):** Agency requires assent, benefit, and control; principals liable for authorized or apparent acts; partnerships form by co-owners sharing profits unless limited liability entities elected.
+
+**Major Subtopics:**
+- **Authority:** Actual, apparent, ratification, inherent agency power.
+- **Vicarious Liability:** Employee vs. independent contractor distinctions.
+- **Partnership Formation:** Sharing profits, intent, partnership by estoppel.
+- **Fiduciary Duties:** Loyalty, care, accounting remedies.
+
+## 16. WILLS & TRUSTS – EXECUTION & REVOCATION
+
+**Rule (23 words):** Valid will requires testamentary capacity, intent, writing, signature, and attestation; revocation occurs by later instrument, physical act with intent, or operation of law.
+
+**Major Subtopics:**
+- **Execution Formalities:** Witness requirements, presence tests, notarization substitutes.
+- **Holographic Wills:** Material provisions handwriting, date issues.
+- **Revocation Methods:** Subsequent wills, physical destruction, divorce effects.
+- **Savings Doctrines:** Dependent relative revocation, incorporation by reference.
+
+## 17. SECURED TRANSACTIONS – ATTACHMENT & PERFECTION
+
+**Rule (24 words):** Article 9 security interest attaches with value, debtor rights, and authenticated agreement; perfection achieved by filing, possession, control, or automatic purchase-money for consumer goods.
+
+**Major Subtopics:**
+- **Scope:** Personal property, fixtures, exclusions, true leases.
+- **Attachment:** Value given, rights in collateral, security agreement.
+- **Perfection:** Filing, possession, control, PMSI super-priority.
+- **Priority:** Lien creditors, buyers in ordinary course, default remedies.
+
+## 18. FAMILY LAW – MARRIAGE & DISSOLUTION
+
+**Rule (22 words):** Valid marriage requires capacity, consent, solemnization; dissolution grounds include no-fault breakdown; property division follows equitable distribution; support determined by needs and ability.
+
+**Major Subtopics:**
+- **Marriage Formation:** Licensing, solemnization, common-law marriage elements.
+- **Annulment:** Void vs. voidable marriages, collateral attacks.
+- **Divorce:** Residency requirements, separation, defenses.
+- **Support & Custody:** Equitable distribution, spousal support factors, best interests.


### PR DESCRIPTION
## Summary
- add a preview-formatted cross-subject headline rulebook matching the existing layout with 20–25 word rule statements and major subtopic bullets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb8dd828688328b0082c525bdb010b