### PR TITLE
Add bar exam headline rules with corrected word counts

### DIFF
--- a/bar_exam_headline_rules.md
+++ b/bar_exam_headline_rules.md
@@ -1,0 +1,41 @@
+# Bar Exam Headline Rules
+*Condensed property law headlines with precise word counts for quick bar prep review.*
+
+## 1. ESTATES & FUTURE INTERESTS
+**Rule (24 words):** Present possessory estates include fee simple absolute, defeasible fees, and life estates; future interests include reversions, remainders, and executory interests that must satisfy RAP.
+
+## 2. CONVEYANCING & RECORDING
+**Rule (22 words):** Recording statutes protect bona fide purchasers; race-notice is majority rule, requiring timely recordation without actual or inquiry notice of prior competing interests.
+
+## 3. EASEMENTS, SERVITUDES & LICENSES
+**Rule (20 words):** Easements create rights to use another's land; appurtenant easements run with land, in gross are personal; licenses are revocable permissions.
+
+## 4. CONCURRENT OWNERSHIP
+**Rule (20 words):** Joint tenancy requires four unities; tenancy in common has no survivorship; tenancy by entirety protects marital property from separate creditors.
+
+## 5. LANDLORD-TENANT LAW
+**Rule (20 words):** Landlord must maintain habitable premises; tenant must pay rent; holdover becomes periodic tenancy; self-help eviction is illegal in most states.
+
+## 6. MORTGAGES, FORECLOSURE & PRIORITY
+**Rule (21 words):** Mortgage creates security interest; foreclosure terminates mortgagor's equity; purchase money mortgages enjoy super-priority over later competing liens on the same collateral.
+
+## 7. ZONING & TAKINGS
+**Rule (21 words):** Zoning regulates land use; takings require just compensation; variance is exception to zoning rules for hardship; exactions must be roughly proportional.
+
+## 8. ADVERSE POSSESSION
+**Rule (21 words):** Hostile, actual, exclusive, continuous possession for statutory period perfects marketable title; color of title reduces the required period to seven years.
+
+## 9. FIXTURES
+**Rule (22 words):** Personal property becomes real property when permanently attached with intent to improve the realty; trade fixtures remain personal property for departing tenants.
+
+## 10. WATER LAW & RIPARIAN RIGHTS
+**Rule (21 words):** Riparian owners have the right to reasonable domestic and agricultural use of water; prior appropriation doctrine governs priority in western states.
+
+## 11. MINERAL RIGHTS & OIL/GAS LAW
+**Rule (21 words):** Mineral rights can be severed from the surface estate; royalty interests and working interests carry distinct development obligations and payment rights.
+
+## 12. SPECIAL PROPERTY INTERESTS
+**Rule (22 words):** Future advances, option contracts, and rights of first refusal create enforceable property interests when supported by consideration, recording, and clear triggering conditions.
+
+## 13. EMINENT DOMAIN & INVERSE CONDEMNATION
+**Rule (22 words):** Government can take private property for public use with just compensation; inverse condemnation occurs without formal judicial proceedings yet still demands payment.


### PR DESCRIPTION
## Summary
- add a dedicated `bar_exam_headline_rules.md` reference outlining the top real property bar headlines
- ensure each rule headline contains 20–25 words and that the displayed parenthetical count matches the actual count

## Testing
- `python - <<'PY' ...` (word-count verification for `bar_exam_headline_rules.md`)


------
https://chatgpt.com/codex/tasks/task_e_68cb8dda9da48328a5d4f02be05468e4